### PR TITLE
Tables & Other Small Heading Tweaks

### DIFF
--- a/components/GoogleDocFormatter.js
+++ b/components/GoogleDocFormatter.js
@@ -48,7 +48,7 @@ const GoogleDocFormatter = ({ rawData }) => {
         />
       );
     } else if (table) {
-      return <GoogleDocTable key={key} table={table} />;
+      return <GoogleDocTable key={key} table={table} rawData={rawData} />;
     } else if (tableOfContents) {
       return (
         <GoogleDocTableOfContents key={key} tableOfContents={tableOfContents} />

--- a/components/GoogleDocFormatter.js
+++ b/components/GoogleDocFormatter.js
@@ -6,6 +6,8 @@ import GoogleDocTable from "./structuralElement/GoogleDocTable";
 import GoogleDocTableOfContents from "./structuralElement/GoogleDocTableOfContents";
 import ParsedList from "./structuralElement/ParsedList";
 
+import styles from "./GoogleDocFormatter.module.scss";
+
 const GoogleDocFormatter = ({ rawData }) => {
   const bodyContent = rawData?.body?.content;
   // One of four types of structural element:
@@ -66,7 +68,7 @@ const GoogleDocFormatter = ({ rawData }) => {
     );
   }
 
-  return <>{structuralElements}</>;
+  return <span className={styles.googleParser}>{structuralElements}</span>;
 };
 
 export default GoogleDocFormatter;

--- a/components/GoogleDocFormatter.module.scss
+++ b/components/GoogleDocFormatter.module.scss
@@ -56,18 +56,12 @@
 }
 
 .parsedTable {
-  font-weight: 500;
-  width: auto !important;
-  border-top: 2px solid var(--lauren-gray);
+  border-collapse: collapse;
+  width: 100%;
 
-  tr:first-child .bold {
-    font-weight: 900;
-    text-transform: uppercase;
-    font-size: 15px;
-    letter-spacing: 1px;
-  }
-
-  .paragraph:last-child {
-    margin-bottom: 0;
+  td {
+    padding: 4px 10px;
+    border: 1px solid var(--gray2);
+    vertical-align: top;
   }
 }

--- a/components/GoogleDocFormatter.module.scss
+++ b/components/GoogleDocFormatter.module.scss
@@ -11,9 +11,18 @@
 }
 
 .heading1 {
-  font-size: 42px;
+  font-size: 32px;
   font-weight: 900;
   margin: 0 0 5px;
+}
+
+.heading2 {
+  font-size: 24px;
+}
+
+.heading3 {
+  font-size: 18px;
+  color: var(--gray4);
 }
 
 .embeddedImage {

--- a/components/GoogleDocFormatterV1.js
+++ b/components/GoogleDocFormatterV1.js
@@ -131,9 +131,7 @@ const GoogleDocFormatterV1 = ({ rawData }) => {
       );
     } else {
       const paragraphStyle = paragraph?.paragraphStyle?.namedStyleType;
-      console.log(paragraphStyle);
       if (paragraphStyle?.includes("TITLE")) {
-        const headingLevel = paragraphStyle.split("_")[1];
         elementList.push(
           React.createElement(
             `div`,

--- a/components/Navigation.js
+++ b/components/Navigation.js
@@ -9,31 +9,35 @@ export const Navigation = ({ menuData }) => {
 
   return (
     <div className={styles.navigation}>
-      <h1>GoInvo</h1>
-      <h2>Playbook</h2>
-      {menuData &&
-        menuData?.map((item) => {
-          const fullName = item.name;
-          const parsedName = item.name.replace(/[0-9].([a-z].)? /, "").trim();
+      <Link href="/">
+        <h1>GoInvo</h1>
+        <h2>Playbook</h2>
+      </Link>
+      <div className={styles.menuContent}>
+        {menuData &&
+          menuData?.map((item) => {
+            const fullName = item.name;
+            const parsedName = item.name.replace(/[0-9].([a-z].)? /, "").trim();
 
-          const url =
-            parsedName.toLowerCase() === "home" ||
-            parsedName.toLowerCase() === "index"
-              ? "/"
-              : `/${parsedName.split(" ").join("-").toLowerCase()}`;
+            const url =
+              parsedName.toLowerCase() === "home" ||
+              parsedName.toLowerCase() === "index"
+                ? "/"
+                : `/${parsedName.split(" ").join("-").toLowerCase()}`;
 
-          return (
-            <div
-              key={item.id}
-              className={cx({
-                [styles.subHeading]: fullName.match(/[0-9].([a-z].) /),
-                [styles.active]: asPath === url,
-              })}
-            >
-              <Link href={url}>{parsedName}</Link>
-            </div>
-          );
-        })}
+            return (
+              <div
+                key={item.id}
+                className={cx({
+                  [styles.subHeading]: fullName.match(/[0-9].([a-z].) /),
+                  [styles.active]: asPath === url,
+                })}
+              >
+                <Link href={url}>{parsedName}</Link>
+              </div>
+            );
+          })}
+      </div>
     </div>
   );
 };

--- a/components/Navigation.module.scss
+++ b/components/Navigation.module.scss
@@ -28,6 +28,21 @@
   }
 
   a {
+    color: black;
+
+    &:hover {
+      h1 {
+        opacity: 0.3;
+      }
+      h2 {
+        opacity: 0.7;
+      }
+    }
+  }
+}
+
+.menuContent {
+  a {
     display: block;
     padding: 4px 10px 5px;
     border-radius: 5px;

--- a/components/paragraph/GDPEInlineObjectElement.js
+++ b/components/paragraph/GDPEInlineObjectElement.js
@@ -1,10 +1,28 @@
 import Image from "next/image";
+import { useEffect, useState } from "react";
 
 // Arbitrary Scaling for Images
 const imageScaling = 1.5;
 
 // Google Doc Paragraph Element Inline Object Element
 const GDPEInlineObjectElement = ({ paragraphElement, rawData }) => {
+  const [windowWidth, setWindowWidth] = useState(0);
+  useEffect(() => {
+    // on resize, get width of container with id mainContainer
+    // and set width of image to that width
+    const resizeWindow = () => {
+      const mainContainer = document.getElementById("mainContainer");
+      setWindowWidth(mainContainer.offsetWidth);
+    };
+
+    window.addEventListener("resize", resizeWindow);
+    resizeWindow();
+
+    return () => {
+      window.removeEventListener("resize", resizeWindow);
+    };
+  }, []);
+
   const inlineObjects = rawData?.inlineObjects;
   const objectId = paragraphElement.inlineObjectElement.inlineObjectId;
   const embeddedObject =
@@ -15,8 +33,8 @@ const GDPEInlineObjectElement = ({ paragraphElement, rawData }) => {
     <Image
       alt={""}
       src={embeddedObject.imageProperties.contentUri}
-      height={embeddedObject.size.height.magnitude * 1.5}
-      width={embeddedObject.size.width.magnitude * 1.5}
+      height={(embeddedObject.size.height.magnitude / 640) * windowWidth}
+      width={(embeddedObject.size.width.magnitude / 640) * windowWidth}
     />
   );
 

--- a/components/structuralElement/GoogleDocParagraph.js
+++ b/components/structuralElement/GoogleDocParagraph.js
@@ -15,7 +15,7 @@ const GoogleDocParagraph = ({ paragraphs, rawData }) => {
         textAlign: paragraphs.paragraphStyle?.alignment,
       }}
     >
-      {paragraphs.elements.map((item, key) => {
+      {paragraphs?.elements?.map((item, key) => {
         if (item.inlineObjectElement) {
           return (
             <GDPEInlineObjectElement

--- a/components/structuralElement/GoogleDocTable.js
+++ b/components/structuralElement/GoogleDocTable.js
@@ -1,6 +1,57 @@
-const GoogleDocTable = () => {
+import React from "react";
+import GoogleDocParagraph from "./GoogleDocParagraph";
+
+import styles from "../GoogleDocFormatter.module.scss";
+
+const GoogleDocTable = ({ table, rawData }) => {
   // TODO: implement google doc table
-  return <div>Google Doc Table Placeholder</div>;
+  // return <div>Google Doc Table Placeholder{JSON.stringify(table)}</div>;
+
+  const cellWidths = [];
+  for (let i = 0; i < table.tableStyle.tableColumnProperties.length; i++) {
+    cellWidths.push(
+      table.tableStyle.tableColumnProperties[i]?.width?.magnitude ?? 1
+    );
+  }
+  const totalWidth = cellWidths.reduce((a, b) => a + b, 0);
+  const cellWidthPercentages = cellWidths.map((width) => {
+    return (width / totalWidth) * 100;
+  });
+
+  console.log(cellWidths);
+
+  const tableData = table.tableRows.map((tableRow, row) => {
+    return (
+      <tr key={"row" + row}>
+        {tableRow.tableCells.map((tableCell, cell) => {
+          return (
+            <td
+              key={"cell" + cell}
+              style={{ width: `${cellWidthPercentages[cell]}%` }}
+            >
+              {tableCell.content.map((elem, k) => {
+                return (
+                  <React.Fragment key={"p" + k}>
+                    {React.createElement(
+                      `span`,
+                      { className: styles.paragraph },
+                      <GoogleDocParagraph paragraphs={elem.paragraph} />
+                    )}
+                  </React.Fragment>
+                );
+              })}
+            </td>
+          );
+        })}
+      </tr>
+    );
+  });
+
+  return (
+    <table className={styles.parsedTable}>
+      <tbody>{tableData}</tbody>
+    </table>
+  );
 };
 
 export default GoogleDocTable;

--- a/pages/[[...slug]].js
+++ b/pages/[[...slug]].js
@@ -84,7 +84,7 @@ export default function Home({ data, menuData }) {
       </Head>
 
       <Navigation menuData={menuData} />
-      <main className={styles.main}>
+      <main id="mainContainer" className={styles.main}>
         <GoogleDocFormatter rawData={data} />
       </main>
     </>

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -2,5 +2,6 @@
   text-align: center;
   padding: 50px;
   text-align: left;
+  max-width: 960px;
   margin-left: var(--navbar-width);
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -9,6 +9,14 @@
   --theme-main-dark: rgb(232, 219, 204);
 
   --navbar-width: 270px;
+
+  --gray1: #f5f5f5;
+  --gray2: #e5e5e5;
+  --gray3: #d4d4d5;
+  --gray4: #737373;
+  --gray5: #404040;
+  --gray6: #262626;
+  --gray7: #171717;
 }
 
 html,


### PR DESCRIPTION
Hello! This pull request basically makes a simple table appear on the website, to address issue #7. Basic formatting and links should also work inside the table (as seen below.)

Other minor updates:
- Some heading CSS tweaks to distinguish between title, h1, h2, h3.
- Images now scale according to the page size (i.e. if you make it the entire google doc page, it'll scale to the max page width which is 960px. If you make it half in google docs, it'll be half on the webpage)
- Top left home link is now a link and clickable

<img width="1066" alt="image" src="https://user-images.githubusercontent.com/276204/215790454-8a23bad8-e32b-49a8-ab94-c284537e6590.png">
