### PR TITLE
feat: convert links wrapped in [square brackets] into a button

### DIFF
--- a/components/GoogleDocFormatter.module.scss
+++ b/components/GoogleDocFormatter.module.scss
@@ -47,7 +47,7 @@
   color: var(--off-white);
 }
 
-.underline {
+.underline:has(:not(a.button)) {
   text-decoration: underline;
 }
 
@@ -63,5 +63,19 @@
     padding: 4px 10px;
     border: 1px solid var(--gray2);
     vertical-align: top;
+  }
+}
+
+a.button {
+  border-radius: 20px;
+  background-color: var(--theme-accent);
+  color: var(--gray1);
+  text-decoration: none !important;
+  padding: 7px 15px;
+  transition: 0.1s opacity;
+
+  &:hover {
+    cursor: pointer;
+    opacity: 0.6;
   }
 }

--- a/components/MaybeLink.js
+++ b/components/MaybeLink.js
@@ -1,4 +1,23 @@
+import styles from "./GoogleDocFormatter.module.scss";
+
+import { isWrappedInSquareBrackets } from "./utils/format";
+
 const MaybeLink = ({ children, link }) => {
+  // check to see if the children text is wrapped in square brackets
+  // if so, we want to render a link
+  const text = children.props.element;
+
+  if (isWrappedInSquareBrackets(text) && link) {
+    // strip first and last characters from text
+    const strippedText = text.slice(1, text.length - 1);
+
+    return (
+      <a className={styles.button} href={link}>
+        {strippedText}
+      </a>
+    );
+  }
+
   if (link) {
     return <a href={link}>{children}</a>;
   }

--- a/components/structuralElement/GoogleDocParagraph.js
+++ b/components/structuralElement/GoogleDocParagraph.js
@@ -9,6 +9,20 @@ const GoogleDocParagraph = ({ paragraphs, rawData }) => {
   // Render each paragraph element. Paragraph elements can contain:
   // ParagraphStyle (stylings), Bullet (is part of a list), and ParagraphElement (actual content)
 
+  // Condense any possible links into one object
+  const elements = paragraphs?.elements;
+  for (let i = 0; i < elements?.length; i++) {
+    if (elements[i].textRun?.content === "[") {
+      if (elements[i + 2].textRun?.content.trim() === "]") {
+        elements[i].textRun.content = "";
+        elements[i + 2].textRun.content = "";
+        elements[i + 1].textRun.content = `[${
+          elements[i + 1].textRun.content
+        }]`;
+      }
+    }
+  }
+
   return (
     <div
       style={{

--- a/components/structuralElement/GoogleDocTable.js
+++ b/components/structuralElement/GoogleDocTable.js
@@ -18,8 +18,6 @@ const GoogleDocTable = ({ table, rawData }) => {
     return (width / totalWidth) * 100;
   });
 
-  console.log(cellWidths);
-
   const tableData = table.tableRows.map((tableRow, row) => {
     return (
       <tr key={"row" + row}>

--- a/components/utils/format.js
+++ b/components/utils/format.js
@@ -1,0 +1,3 @@
+export const isWrappedInSquareBrackets = (text) => {
+  return text[0] === "[" && text[text.length - 1] === "]";
+};

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -3,7 +3,7 @@ import "../styles/globals.css";
 export default function App({ Component, pageProps }) {
   return (
     <>
-      <Component {...pageProps} />;
+      <Component {...pageProps} />
     </>
   );
 }


### PR DESCRIPTION
This update references issue #8, creating links into 'buttons'. I ended up going with a different strategy,  @ericbenwa please let me know if you'd like this changed. 

There are now two ways to specify a 'button'. Either wrap the link between square brackets [[like this]](https://www.youtube.com/watch?v=dQw4w9WgXcQ), or wrap the link with the text itself in square brackets [[like this](https://www.youtube.com/watch?v=dQw4w9WgXcQ)] 

Google Doc example:
<img width="351" alt="image" src="https://user-images.githubusercontent.com/276204/216207683-55bbc861-7681-4d53-b0af-7376f3f815dc.png">

I've also chosen a lovely dark pastel red to match the theme color, but if you'd like I can change it to blue (and/or change the theme color as well)

(sorry for making a mess of this homepage - feel free to edit the Google Doc and remove all the examples!)

Also in this update:
- remove extraneous logs
- removed stray semicolon that was rendering

<img width="772" alt="image" src="https://user-images.githubusercontent.com/276204/216207473-1765e9e5-501b-4c45-a714-bc33d5d5675d.png">
