### PR TITLE
fix: allow punctuations in titles and refactor page id/slug generator

### DIFF
--- a/components/Navigation.js
+++ b/components/Navigation.js
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 
 import styles from "./Navigation.module.scss";
 import cx from "classnames";
+import { standardizePageId } from "./utils/format";
 
 export const Navigation = ({ menuData, isMenuOpen, setIsMenuOpen }) => {
   const { asPath } = useRouter();
@@ -43,15 +44,13 @@ export const Navigation = ({ menuData, isMenuOpen, setIsMenuOpen }) => {
           {menuData &&
             menuData?.map((item, key) => {
               const fullName = item.name;
-              const parsedName = item.name
-                .replace(/[0-9].([a-z].)? /, "")
-                .trim();
+              const pageTitle = item.name;
 
               const url =
-                parsedName.toLowerCase() === "home" ||
-                parsedName.toLowerCase() === "index"
+                pageTitle.toLowerCase() === "home" ||
+                pageTitle.toLowerCase() === "index"
                   ? "/"
-                  : `/${parsedName.split(" ").join("-").toLowerCase()}`;
+                  : `/${standardizePageId(pageTitle)}`;
 
               // Don't show the first menu item because we're assuming that
               // it's the home page.
@@ -70,7 +69,9 @@ export const Navigation = ({ menuData, isMenuOpen, setIsMenuOpen }) => {
                     setIsMenuOpen(false);
                   }}
                 >
-                  <Link href={url}>{parsedName}</Link>
+                  <Link href={url}>
+                    {pageTitle.replace(/[0-9].([a-z].)? /, "")}
+                  </Link>
                 </div>
               );
             })}

--- a/components/utils/format.js
+++ b/components/utils/format.js
@@ -1,3 +1,13 @@
 export const isWrappedInSquareBrackets = (text) => {
   return text[0] === "[" && text[text.length - 1] === "]";
 };
+
+export const standardizePageId = (title) => {
+  return title
+    .replace(/[0-9].([a-z].)? /, "")
+    .split(" ")
+    .join("-")
+    .replace(/[^0-9a-zA-Z-]/g, "")
+    .trim()
+    .toLowerCase();
+};

--- a/pages/[[...slug]].js
+++ b/pages/[[...slug]].js
@@ -6,6 +6,7 @@ import GoogleDocFormatter from "../components/GoogleDocFormatter";
 
 import styles from "../styles/Home.module.css";
 import { Navigation } from "../components/Navigation";
+import { standardizePageId } from "../components/utils/format";
 
 export async function getStaticPaths() {
   return {
@@ -49,13 +50,10 @@ export async function getStaticProps({ params }) {
   const homeDocumentId = fileList[0].id;
 
   const documentId =
-    fileList.find(
-      (item) =>
-        item.name
-          .toLowerCase()
-          .replace(/[0-9].([a-z].)? /, "")
-          .trim() === fileName.toLowerCase()
-    )?.id ?? homeDocumentId;
+    fileList.find((item) => {
+      console.log(item.name, fileName);
+      return standardizePageId(item.name) === standardizePageId(fileName);
+    })?.id ?? homeDocumentId;
 
   // fetch the specific file
   const gsapi = google.docs({ version: "v1", auth: client });

--- a/pages/[[...slug]].js
+++ b/pages/[[...slug]].js
@@ -51,7 +51,6 @@ export async function getStaticProps({ params }) {
 
   const documentId =
     fileList.find((item) => {
-      console.log(item.name, fileName);
       return standardizePageId(item.name) === standardizePageId(fileName);
     })?.id ?? homeDocumentId;
 


### PR DESCRIPTION
This small update allows punctuations (for example the question mark in, 'got feedback?')  to be a valid page. The generated URL slug will remove any special characters except for 0-9, a-z, A-Z, -.

<img width="1039" alt="image" src="https://user-images.githubusercontent.com/276204/228936742-2ca661df-402f-4c85-9008-57228a235dbb.png">
