### PR TITLE
Link Behavior; Update Documentation; Fix Link Glitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,45 @@
-## running.goinvo.com
+# running.goinvo.com
 
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app), designed to pull data from Google Docs and display them.
 
-## Setup And Development
+## Editing the Content
+
+The content of [running.goinvo.com](running.goinvo.com) can be edited by modifying the Google Drive documents that are internal to the GoInvo team. 
+
+### Navigation
+Each document in the root directory will be listed as a menu item. The ordering will be based off of the number that precedes the first detected period `.` 
+
+Submenus can be used here by using letter numbering. For example, a valid structure for file names is:
+
+ 1\. Page 1<br>
+ 2\. Page 2<br>
+ 3\. Page 3<br>
+3.b. Page 3b<br>
+3.c. Page 3c
+
+When rendered, `3b` and `3c` will be nested under page 3
+
+### Document Hiding
+
+If you don't want a document to show up in the Navigation, there are two options to hide it
+
+- Use a folder and toss the documents in there
+- Append `#unlisted` to the end of the Google Document name. For example, if the document was named `1. Page 1` making this `1. Page 1#unlisted` would prevent this document from showing up in the menu
+
+### Lightboxes
+
+Lightboxes are useful to keep the user on the site while being able to view the pertinent information. Any link can be converted to open in an lightbox iframe. Add `#lightbox` to the end of the link on the Google Document link to trigger the lightbox.
+
+### Two Columns
+
+We detect if columns are present via a `[cols: 2]` at the end of a `Heading 3` in Google Docs. If so, the immediate following content will be split into a special format which is 2 columns on desktop and 1 slim column on mobile. This is currently used for `Quick Links` and `Guides`, which are typically at the top of each document page.
+
+### Links & Buttons
+
+Links by default will open in a new tab if they do not point within the `running.goinvo` domain. If you wish to change this behavior and force the link to replace the existing window, append `#self` to the end of the link.
+
+Buttons are links but in a nice pill-shaped container. To summon a button, the **text** itself should be surrounded by square brackets `[]` 
+## Setup And Development of the Code
 
 1. Clone this repo!
 1. Navigate to the root using Terminal on a Mac, or some sort of bash shell if you're on a PC. Run `yarn` (if you don't have yarn, you may need to [install it](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable). Yarn is a package management system with a variety of debatable advantages over npm.

--- a/components/GoogleDocFormatter.js
+++ b/components/GoogleDocFormatter.js
@@ -31,7 +31,11 @@ const GoogleDocFormatter = ({ rawData }) => {
         ) {
           activeList.push(paragraph);
           activeBulletStyle = paragraph.bullet.listId;
-          return null;
+
+          // this is the last item - if we return null, it won't render
+          if (key !== bodyContent.length - 1) {
+            return null;
+          }
         } else {
           // We've reached a new type of list
           const list = [...activeList];
@@ -42,7 +46,6 @@ const GoogleDocFormatter = ({ rawData }) => {
           );
         }
       }
-
       // not a list, but previously there was a list
       if (listElement === null && activeList.length > 0) {
         const list = [...activeList];
@@ -55,13 +58,14 @@ const GoogleDocFormatter = ({ rawData }) => {
       return (
         <>
           {listElement ? listElement : null}
-          {activeList.length === 0 && (
-            <GoogleDocParagraph
-              key={key}
-              paragraphs={paragraph}
-              rawData={rawData}
-            />
-          )}
+          {(activeList.length === 0 &&
+            !(key === bodyContent.length - 1 && paragraph.bullet !== undefined)) && (
+              <GoogleDocParagraph
+                key={key}
+                paragraphs={paragraph}
+                rawData={rawData}
+              />
+            )}
         </>
       );
     }
@@ -138,6 +142,7 @@ const GoogleDocFormatter = ({ rawData }) => {
       }
     }
   }
+
   return (
     <span className={styles.googleParser}>{rebuiltStructuralElements}</span>
   );

--- a/components/MaybeLink.js
+++ b/components/MaybeLink.js
@@ -7,20 +7,26 @@ const MaybeLink = ({ children, link }) => {
   // if so, we want to render a link
   const text = children.props.element;
 
+  // if link contains #self, then show in current tab. otherwise, 
+  // open in new tab if it's not a running.goinvo link
+  const target = link?.includes("#self") ? "_self" :
+    link?.includes("running.goinvo") ? "_self" : "_blank";
+
   if (isWrappedInSquareBrackets(text) && link) {
     // strip first and last characters from text
     const strippedText = text.slice(1, text.length - 1);
 
     return (
-      <a className={styles.button} href={link}>
+      <a className={styles.button} href={link} target={target}>
         {strippedText}
       </a>
     );
   }
 
   if (link) {
-    return <a href={link}>{children}</a>;
+    return <a href={link} target={target}>{children}</a>;
   }
+
   return <>{children}</>;
 };
 


### PR DESCRIPTION
This potpourri of updates makes it so links by default open in a new tab unless it's under the running.goinvo.com domain. Append #self at the end of a link to keep from opening in a new tab 

Updated documentation because it's now a lot of information

Fix the bug to make it so that links at the end of a parsed document shows up

![image](https://user-images.githubusercontent.com/276204/233227858-c2e1a923-91a8-4f97-8447-a9298b976d40.png)
