### PR TITLE
Lightbox Updates and Minor Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ If you don't want a document to show up in the Navigation, there are two options
 
 Lightboxes are useful to keep the user on the site while being able to view the pertinent information. Any link can be converted to open in an lightbox iframe. Add `#lightbox` to the end of the link on the Google Document link to trigger the lightbox.
 
+If you'd like the link to be a preview of the lightbox content itself, add `#lightbox-preview` to the end of a link and a mini iframe thumbnail will render. This however takes longer than just loading a simple image, so sparse usage is advised. 
+
 ### Two Columns
 
 We detect if columns are present via a `[cols: 2]` at the end of a `Heading 3` in Google Docs. If so, the immediate following content will be split into a special format which is 2 columns on desktop and 1 slim column on mobile. This is currently used for `Quick Links` and `Guides`, which are typically at the top of each document page.

--- a/components/GoogleDocFormatter.module.scss
+++ b/components/GoogleDocFormatter.module.scss
@@ -121,7 +121,7 @@
   iframe {
     border: none;
     position: relative;
-    top: -20px;
+    top: -10px;
     left: -15px;
     width: calc(100% + 30px);
     height: calc(100% + 60px);
@@ -131,6 +131,10 @@
 
   &:hover {
     cursor: pointer;
+
+    &:after {
+      background-color: rgba(0, 0, 0, 0.05);
+    }
   }
 
   &:after {
@@ -142,7 +146,6 @@
     height: 100%;
     background-color: rgba(255, 255, 255, 0);
     z-index: 2;
-
   }
 }
 

--- a/components/GoogleDocFormatter.module.scss
+++ b/components/GoogleDocFormatter.module.scss
@@ -70,6 +70,7 @@
   grid-template-columns: repeat(2, 1fr);
   gap: 30px;
   line-height: 0;
+  align-items: stretch;
 
   .embeddedImage {
     width: 100%;
@@ -88,6 +89,11 @@
   &.quick-links {
     gap: 10px;
   }
+
+  .previewIFrameContainer {
+    width: 100% !important;
+    height: 100% !important;
+  }
 }
 
 .embeddedImage {
@@ -97,10 +103,46 @@
     margin-right: 20px;
     line-height: 0;
 
-    &:hover {
-      cursor: pointer;
-      filter: brightness(0.9);
-    }
+  }
+
+  &.hasLink:hover img {
+    cursor: pointer;
+    filter: brightness(0.9);
+  }
+}
+
+.previewIFrameContainer {
+  display: inline-block;
+  border: none;
+  position: relative;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+
+  iframe {
+    border: none;
+    position: relative;
+    top: -20px;
+    left: -15px;
+    width: calc(100% + 30px);
+    height: calc(100% + 60px);
+    position: relative;
+  }
+
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  &:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(255, 255, 255, 0);
+    z-index: 2;
+
   }
 }
 

--- a/components/Lightbox.js
+++ b/components/Lightbox.js
@@ -2,20 +2,15 @@ import { useState } from "react";
 
 import styles from "./Lightbox.module.scss";
 import cx from "classnames";
+import { formatEmbedUrl } from "../utils/format";
 
 export const Lightbox = ({ children, url }) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  // google slides needs to be /embed instead of /pub, so replace it if we see it
-  url = url.replace("/pub", "/embed");
-
-  // figma needs to be under the figma.com/embed route
-  if (url.includes("figma.com")) {
-    url = `https://www.figma.com/embed?embed_host=share&url=${url}`;
-  }
+  url = formatEmbedUrl(url);
 
   return (
-    <div>
+    <>
       <div
         onClick={() => setIsOpen(!isOpen)}
         className={cx(styles.background, { [styles.visible]: isOpen })}
@@ -25,7 +20,7 @@ export const Lightbox = ({ children, url }) => {
         </div>
         <iframe src={url} />
       </div>
-      <div onClick={() => setIsOpen(!isOpen)}>{children}</div>
-    </div>
+      <div style={{ height: '100%' }} onClick={() => setIsOpen(!isOpen)}>{children}</div>
+    </>
   );
 };

--- a/components/Lightbox.module.scss
+++ b/components/Lightbox.module.scss
@@ -8,7 +8,7 @@
   z-index: 100;
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: cent‰er;
   transition: 0.2s opacity;
   opacity: 0;
   pointer-events: none;
@@ -19,9 +19,9 @@
   }
 
   iframe {
-    height: calc(100% - 150px);
-    width: calc(100% - 120px);
-    margin-top: 30px;
+    height: calc(100% - 120px);
+    width: calc(100% - 40px);
+    margin-top: 60px;
     border: none;
     border-radius: 5px;
     box-shadow: 0 0 40px rgba(0, 0, 0, 0.5);

--- a/components/Lightbox.module.scss
+++ b/components/Lightbox.module.scss
@@ -49,6 +49,7 @@
       position: fixed;
       top: 60px;
       left: 20px;
+      margin-top: 0;
 
       width: calc(100% - 40px);
       height: calc(100% - 90px);

--- a/components/Lightbox.module.scss
+++ b/components/Lightbox.module.scss
@@ -19,8 +19,9 @@
   }
 
   iframe {
-    width: 80%;
-    height: 80%;
+    height: calc(100% - 150px);
+    width: calc(100% - 120px);
+    margin-top: 30px;
     border: none;
     border-radius: 5px;
     box-shadow: 0 0 40px rgba(0, 0, 0, 0.5);

--- a/components/Navigation.module.scss
+++ b/components/Navigation.module.scss
@@ -95,8 +95,8 @@
   width: calc(100% - 80px);
 
   a {
-    color: white;
-    text-decoration: none;
+    color: white !important;
+    text-decoration: underline;
   }
 }
 

--- a/components/paragraph/GDPEInlineObjectElement.js
+++ b/components/paragraph/GDPEInlineObjectElement.js
@@ -3,6 +3,9 @@ import { useEffect, useState } from "react";
 
 import styles from "../GoogleDocFormatter.module.scss";
 import { Lightbox } from "../Lightbox";
+import { formatEmbedUrl } from "../../utils/format";
+
+import cx from "classnames";
 
 // Arbitrary Scaling for Images
 const imageScaling = 1.5;
@@ -33,7 +36,10 @@ const GDPEInlineObjectElement = ({ paragraphElement, rawData }) => {
   const link = paragraphElement.inlineObjectElement.textStyle.link;
 
   const imageElement = (
-    <span className={styles.embeddedImage}>
+    <span className={cx({
+      [styles.embeddedImage]: true,
+      [styles.hasLink]: link
+    })}>
       <Image
         alt={""}
         src={embeddedObject.imageProperties.contentUri}
@@ -47,6 +53,25 @@ const GDPEInlineObjectElement = ({ paragraphElement, rawData }) => {
     // check if link.url contains #lightbox
     // if it does, then return the imageElement wrapped in a lightbox
     if (link.url.includes("#lightbox")) {
+      if (link.url.includes("preview")) {
+        // this wants a live preview - show the content directly
+
+        return <Lightbox url={link.url}>
+          <div className={styles.previewIFrameContainer}
+            style={{
+              height: (embeddedObject.size.height.magnitude / 640) * windowWidth,
+              width: (embeddedObject.size.width.magnitude / 640) * windowWidth
+            }}
+          >
+            <iframe
+              className={styles.previewIFrame}
+              src={formatEmbedUrl(link.url)}
+              width={'100%'}
+              height={'100%'}
+            />
+          </div>
+        </Lightbox >;
+      }
       return <Lightbox url={link.url}>{imageElement}</Lightbox>;
     }
     return <a href={link.url}>{imageElement}</a>;

--- a/pages/api/cron.js
+++ b/pages/api/cron.js
@@ -9,7 +9,9 @@ export default async function handler(req, res) {
   urls.push('https://running.goinvo.com');
   urls.push('https://running.goinvo.com/index');
 
-  for (let i = 0; i < 4; i++) {
+  const CYCLES = 4;
+
+  for (let i = 0; i < CYCLES; i++) {
     setTimeout(async () => {
       for (const url of urls) {
         console.log('visiting ' + url);
@@ -18,5 +20,8 @@ export default async function handler(req, res) {
     }, i * 3000);
   }
 
-  res.status(200).end('Good!');
+  // Forced delay for all cycles to complete
+  setTimeout(() => {
+    res.status(200).end('Good!');
+  }, (CYCLES + 1) * 3000)
 }

--- a/utils/format.js
+++ b/utils/format.js
@@ -11,3 +11,15 @@ export const standardizePageId = (title) => {
     .trim()
     .toLowerCase();
 };
+
+export const formatEmbedUrl = (url) => {
+  // google slides needs to be /embed instead of /pub, so replace it if we see it
+  url = url.replace("/pub", "/embed");
+
+  // figma needs to be under the figma.com/embed route
+  if (url.includes("figma.com")) {
+    url = `https://www.figma.com/embed?embed_host=share&url=${url}`;
+  }
+
+  return url;
+}


### PR DESCRIPTION
Big ticket items:
- lightbox previews are larger
- image links no longer turn into a cursor when there's nothing
- fix minor bug with links
- new `#lightbox-preview` feature, which loads a live iframe as the preview thumbnail when `#lightbox-preview` is added to the end of a link
- updates to fix homepage image link and broken link bugs

https://capture.dropbox.com/SuwoJZpXJkTjasJe